### PR TITLE
Improve visual gameplay with larger board and gridlines

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,8 +16,7 @@ body {
 }
 
 .wrapper {
-    width: 65vmin;
-    height: 70vmin;
+    width: 80vmin;
     display: flex;
     flex-direction: column;
     border-radius: 5px;
@@ -35,11 +34,15 @@ body {
 
 .play-board {
     width: 100%;
-    height: 100%;
+    aspect-ratio: 1;
     display: grid;
     grid-template-rows: repeat(30, 1fr);
     grid-template-columns: repeat(30, 1fr);
     background-color: #212837;
+    background-image: 
+        repeating-linear-gradient(0deg, #2a3142 0px, #2a3142 1px, transparent 1px, transparent),
+        repeating-linear-gradient(90deg, #2a3142 0px, #2a3142 1px, transparent 1px, transparent);
+    background-size: calc(100% / 30) calc(100% / 30);
 }
 
 .play-board .food {


### PR DESCRIPTION
This PR changes the playing board by adding gridlines and increasing the size while maintaining a square shape. This matters because the previous UI only gave room for a small area of movement and it was not able to distinguish between tiles. I verified this by opening a live preview on the branch where changes were made. I expected the playing board to be significantly larger than the original and that it includes lines to differentiate between tiles. This is exactly what I observed.




Before: 
<img width="1575" height="928" alt="image" src="https://github.com/user-attachments/assets/4f7c1dd0-8ae5-4a41-8b26-c56009294b05" />

After: 
<img width="1528" height="920" alt="image" src="https://github.com/user-attachments/assets/561b6997-7cc4-4273-91bb-205128ed2bd9" />
